### PR TITLE
pkg-config: Fix typo in includedir

### DIFF
--- a/ggml.pc.in
+++ b/ggml.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-includrdir=${prefix}/include
+includedir=${prefix}/include
 libdir=${prefix}/lib
 
 Name: ggml


### PR DESCRIPTION
This fixes broken build on ubuntu-latest, where it appears that the fields in the pkg-config file are validated (they were not on my virtual machine).